### PR TITLE
feat: 依據編輯 annotation 物種 api 調整修改

### DIFF
--- a/src/pages/Project/ProjectStudyAreas/AnnotationsSheet.vue
+++ b/src/pages/Project/ProjectStudyAreas/AnnotationsSheet.vue
@@ -186,7 +186,10 @@ export default {
         hotInstance.selectRows(val);
       }
     },
-    projectDataFields: 'setSheetHeader',
+    projectDataFields: function() {
+      this.setSheetHeader();
+      this.setSheetColumn();
+    },
   },
   computed: {
     ...annotations.mapState(['annotationsTotal']),

--- a/src/pages/Project/ProjectStudyAreas/AnnotationsSheet.vue
+++ b/src/pages/Project/ProjectStudyAreas/AnnotationsSheet.vue
@@ -368,14 +368,13 @@ export default {
     changeAnnotation(changes) {
       if (!!changes && this.isEdit === true) {
         changes.forEach(({ 0: row, 1: prop, 3: newVal }) => {
-          let annotation = R.pipe(
-            R.clone,
-            R.pick(['fields', 'species']),
-          )(this.annotations[row]);
+          let annotation = {
+            fields: R.clone(this.annotations[row].fields),
+            speciesTitle:
+              prop === 'species' ? newVal : this.annotations[row].species.title,
+          };
 
-          if (prop === 'species') {
-            annotation.speciesTitle = newVal;
-          } else {
+          if (prop !== 'species') {
             const targetIdx = R.findIndex(R.propEq('dataField', prop))(
               annotation.fields,
             );
@@ -391,6 +390,9 @@ export default {
               annotation.fields[targetIdx].value = newVal;
             }
           }
+
+          // fields 內的資料如果 value 不存在要過濾，不然後端會錯誤
+          annotation.fields = annotation.fields.filter(v => !!v.value);
 
           this.setAnnotations({
             annotationId: this.annotations[row].id,

--- a/src/pages/Project/ProjectStudyAreas/AnnotationsSheet.vue
+++ b/src/pages/Project/ProjectStudyAreas/AnnotationsSheet.vue
@@ -244,7 +244,8 @@ export default {
           ? this.annotations[row].species // #1 來源
           : R.find(R.propEq('title', title), this.projectSpecies); // #2 來源
 
-        if (sp) {
+        // 不明原因有時後 sp.title 會與 title 值不相同，造成資料還是顯示舊的 issue #125
+        if (sp && sp.title === title) {
           // 如果 sp 存在才要用一般方式判斷
           td.innerHTML = sp.title;
 

--- a/src/pages/Project/ProjectStudyAreas/RightSide.vue
+++ b/src/pages/Project/ProjectStudyAreas/RightSide.vue
@@ -158,7 +158,7 @@ export default {
   },
   watch: {
     currentAnnotationIdx: function() {
-      this.getRevision(this.currentData.id);
+      this.currentData && this.getRevision(this.currentData.id);
     },
   },
   computed: {
@@ -171,7 +171,7 @@ export default {
       return this.annotations[this.currentAnnotationIdx];
     },
     currentImage() {
-      return this.currentData.file;
+      return this.currentData && this.currentData.file;
     },
     hasImage() {
       return idx(this.currentImage, _ => _.url);

--- a/src/pages/Project/ProjectStudyAreas/index.vue
+++ b/src/pages/Project/ProjectStudyAreas/index.vue
@@ -376,6 +376,7 @@ export default {
     },
     async doSearch() {
       if (this.query.cameraLocations.length === 0) {
+        this.resetAnnotations();
         return;
       }
       const { query } = this;


### PR DESCRIPTION
主要調整依據此 issue https://github.com/TaiBIF/camera-trap-api/issues/163
並且調整物種欄位編輯規格

- 改成 autocomplete 而不是下拉選單，使用者輸入文字時會自動提示預設物種所含的項目
- 如果使用者要新增不再預設物種內的 `新物種` 則是直接輸入物種名稱則會新增

bugfix
- 當相機全部取消選取時將 sheet 清空
- currentAnnotationIdx 為 -1 時右側影像檢視及版本紀錄會有 error