### PR TITLE
remove fix timezone at utc+0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10577,14 +10577,6 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
-    "moment-timezone": {
-      "version": "0.5.25",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.25.tgz",
-      "integrity": "sha512-DgEaTyN/z0HFaVcVbSyVCUU6HeFdnNC3vE4c9cgu2dgMTvjBUBdBzWfasTBmAW45u5OIMeCJtU8yNjM22DHucw==",
-      "requires": {
-        "moment": ">= 2.9.0"
-      }
-    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "leaflet": "^1.4.0",
     "markdown-it": "^8.4.2",
     "moment": "^2.24.0",
-    "moment-timezone": "^0.5.25",
     "popper.js": "^1.14.7",
     "query-string": "^6.4.2",
     "ramda": "^0.26.1",

--- a/src/utils/dateHelper.js
+++ b/src/utils/dateHelper.js
@@ -1,7 +1,4 @@
 import moment from 'moment';
-import 'moment-timezone';
-
-moment.tz.setDefault('Etc/GMT');
 
 export const getTodayDate = () => moment(Date.now());
 


### PR DESCRIPTION
relate to : #159 #168 #187 #205 #210 
* 移除 timezone 設定, 改回使用 user timezone.
ps. 套用 user timezone 會出現在不同時區出現不同資料的問題 (https://github.com/TaiBIF/camera-trap-vueapp/pull/165#issuecomment-495907521), 
這部分後續仍須評估是否需調整。
不過不論後續決議如何調整，都應移除目前 UTC+0 的設定，所以先發 PR 處理這段