### PR TITLE
Feature/issue 182 map add species marker

### DIFF
--- a/src/constant/chartColors.js
+++ b/src/constant/chartColors.js
@@ -1,9 +1,13 @@
 export default [
+  '#F19C79',
+  '#CC76BA',
+  '#F6F4D2',
+  '#7B0828',
+  '#5569B5',
   '#5DB897',
   '#AACAEE',
-  '#7E99E5',
-  '#5569B5',
-  '#CC76BA',
-  '#FFC8EB',
   '#BDE9A5',
+  '#EFCEFA',
+  '#7E99E5',
+  '#BCAC9B',
 ];

--- a/src/constant/chartColors.js
+++ b/src/constant/chartColors.js
@@ -1,0 +1,9 @@
+export default [
+  '#5DB897',
+  '#AACAEE',
+  '#7E99E5',
+  '#5569B5',
+  '#CC76BA',
+  '#FFC8EB',
+  '#BDE9A5',
+];

--- a/src/pages/Project/Detail.vue
+++ b/src/pages/Project/Detail.vue
@@ -42,10 +42,22 @@ export default {
     this.getProjectStudyAreas(this.projectId);
     this.loadSpeciesGroupByStudyArea(this.projectId);
     this.fetchProjectCameraLocations();
+    if (this.selectedStudyAreaId !== 'all') {
+      this.loadSpeciesGroupByCameraLocation({
+        projectId: this.projectId,
+        studyAreaId: this.selectedStudyAreaId,
+      });
+    }
   },
   watch: {
     selectedStudyAreaId() {
       this.fetchProjectCameraLocations();
+      if (this.selectedStudyAreaId !== 'all') {
+        this.loadSpeciesGroupByCameraLocation({
+          projectId: this.projectId,
+          studyAreaId: this.selectedStudyAreaId,
+        });
+      }
     },
   },
   computed: {
@@ -64,6 +76,7 @@ export default {
       'getProjectStudyAreas',
       'getProjectCameraLocations',
       'loadSpeciesGroupByStudyArea',
+      'loadSpeciesGroupByCameraLocation',
     ]),
     fetchProjectCameraLocations() {
       if (this.selectedStudyAreaId && this.selectedStudyAreaId !== 'all') {

--- a/src/pages/Project/Detail.vue
+++ b/src/pages/Project/Detail.vue
@@ -40,6 +40,7 @@ export default {
   mounted() {
     this.getProjectDetail(this.projectId);
     this.getProjectStudyAreas(this.projectId);
+    this.loadSpeciesGroupByStudyArea(this.projectId);
     this.fetchProjectCameraLocations();
   },
   watch: {
@@ -62,6 +63,7 @@ export default {
     ...studyAreas.mapActions([
       'getProjectStudyAreas',
       'getProjectCameraLocations',
+      'loadSpeciesGroupByStudyArea',
     ]),
     fetchProjectCameraLocations() {
       if (this.selectedStudyAreaId && this.selectedStudyAreaId !== 'all') {

--- a/src/pages/Project/ProjectInfo/ProjectMap.vue
+++ b/src/pages/Project/ProjectInfo/ProjectMap.vue
@@ -20,9 +20,9 @@
           :lat-lng="area.position"
           :draggable="false"
           :radius="studyAreaRadius"
-          :color="markerColor.area.color"
-          :fillColor="markerColor.area.color"
-          :fillOpacity="showSpecies ? 0.2 : 0.8"
+          :color="markerColor.area"
+          :fillColor="markerColor.area"
+          :fillOpacity="showSpecies ? 0.1 : 0.8"
           @click="selectArea(area.path)"
         >
           <l-tooltip
@@ -65,9 +65,9 @@
           :lat-lng="camera.position"
           :draggable="false"
           :radius="cameraRadius"
-          :color="markerColor.camera.color"
-          :fillColor="markerColor.camera.color"
-          fillOpacity="0.2"
+          :color="markerColor.camera"
+          :fillColor="markerColor.camera"
+          :fillOpacity="0.1"
           @click="selectCamera(camera.id)"
           @mouseover="$emit('hoverCamera', camera.id)"
           @mouseout="$emit('hoverCamera')"
@@ -115,6 +115,12 @@
           :color="'#FFAF00'"
         />
       </l-layer-group>
+      <l-control position="topright" class="species__legend">
+        <div v-for="species in speciesLegend" :key="species.id">
+          <span :style="{ backgroundColor: species.color }"></span>
+          {{ species.name }}
+        </div>
+      </l-control>
     </l-map>
     <div class="checkbox__container checkbox">
       <div>
@@ -168,6 +174,7 @@
 <script>
 import {
   LCircle,
+  LControl,
   LLayerGroup,
   LMap,
   LMarker,
@@ -222,13 +229,12 @@ const ErrorCameraIconSelect = L.icon({
 
 const defaultZoom = { area: 8, camera: 12 };
 const defaultPosition = { lng: 120.982024, lat: 23.973875 };
-
 const positonShift = [
-  { lat: 0.000002, lng: 0.000002 },
-  { lat: -0.000002, lng: 0.000002 },
-  { lat: -0.000002, lng: -0.000001 },
-  { lat: 0.000001, lng: 0.000002 },
-  { lat: 0.000002, lng: -0.000002 },
+  { lng: 0.0000012, lat: 0.000002 },
+  { lng: -0.0000012, lat: 0.000002 },
+  { lng: -0.000002, lat: -0.000001 },
+  { lng: 0, lat: -0.000003 },
+  { lng: 0.000002, lat: -0.000001 },
 ];
 
 export default {
@@ -241,6 +247,7 @@ export default {
     LCircle,
     LTooltip,
     LLayerGroup,
+    LControl,
   },
   props: {
     activeCameraId: {
@@ -261,14 +268,8 @@ export default {
       studyAreaRadius: 10000,
       cameraRadius: 5000,
       markerColor: {
-        area: {
-          color: 'rgba(42, 127, 96, .43)',
-          fillColor: 'rgb(42, 127, 96)',
-        },
-        camera: {
-          color: 'rgba(17, 138, 178,.43)',
-          fillColor: 'rgb(17, 138, 178)',
-        },
+        area: 'rgb(42, 127, 96)',
+        camera: 'rgb(17, 138, 178)',
       },
       showForestBoundary: false,
       showSpecies: false,
@@ -279,86 +280,94 @@ export default {
       },
       startDisplayDate: '2010-05', // TODO: get from API
       endDisplayDate: '2016-11', // TODO: get from API
+      species: {
+        // TODO: get from API
+        '5cd661e332a98b60839c6caf': '山羌',
+        '5cd661e332a98b60839c6caa': '空拍',
+        '5cd661e332a98b60839c6cab': '測試',
+        '5cd661e332a98b60839c6cb1': '獼猴',
+        '5cd661e332a98b60839c6cb2': '鼬獾',
+      },
       speciesMarkers: {
         // TODO: get from API
         '5ceb8464caaeca01402d6354': [
           {
-            name: 'A',
-            speciesId: '5cd661e332a98b60839c6cab',
-            numberOfRecords: 28,
+            species: '山羌',
+            speciesId: '5cd661e332a98b60839c6caf',
+            numberOfRecords: 1000,
           },
           {
-            name: 'B',
-            speciesId: '5cd661e332a98b60839c6cab',
-            numberOfRecords: 36,
+            species: '空拍',
+            speciesId: '5cd661e332a98b60839c6caa',
+            numberOfRecords: 1000,
           },
           {
-            name: 'C',
+            species: '測試',
             speciesId: '5cd661e332a98b60839c6cab',
-            numberOfRecords: 145,
+            numberOfRecords: 1000,
           },
           {
-            name: 'D',
-            speciesId: '5cd661e332a98b60839c6cab',
-            numberOfRecords: 1515,
+            species: '獼猴',
+            speciesId: '5cd661e332a98b60839c6cb1',
+            numberOfRecords: 1000,
           },
           {
-            name: 'E',
-            speciesId: '5cd661e332a98b60839c6cab',
-            numberOfRecords: 0,
+            species: '鼬獾',
+            speciesId: '5cd661e332a98b60839c6cb2',
+            numberOfRecords: 1000,
           },
         ],
         '5ceb83f7caaecaca502d62d9': [
           {
-            name: 'A',
-            speciesId: '5cd661e332a98b60839c6cab',
+            species: '山羌',
+            speciesId: '5cd661e332a98b60839c6caf',
             numberOfRecords: 78,
           },
           {
-            name: 'B',
-            speciesId: '5cd661e332a98b60839c6cab',
+            species: '空拍',
+            speciesId: '5cd661e332a98b60839c6caa',
             numberOfRecords: 66,
           },
           {
-            name: 'C',
+            species: '測試',
             speciesId: '5cd661e332a98b60839c6cab',
             numberOfRecords: 45,
           },
           {
-            name: 'D',
-            speciesId: '5cd661e332a98b60839c6cab',
+            species: '獼猴',
+            speciesId: '5cd661e332a98b60839c6cb1',
             numberOfRecords: 185,
           },
           {
-            name: 'E',
-            speciesId: '5cd661e332a98b60839c6cab',
+            species: '鼬獾',
+            speciesId: '5cd661e332a98b60839c6cb2',
             numberOfRecords: 30,
           },
         ],
         '5ceb8488caaecaf5472d63a8': [
           {
-            name: 'A',
-            speciesId: '5cd661e332a98b60839c6cab',
+            species: '山羌',
+            speciesId: '5cd661e332a98b60839c6caf',
             numberOfRecords: 278,
           },
           {
-            name: 'B',
-            speciesId: '5cd661e332a98b60839c6cab',
+            species: '空拍',
+            speciesId: '5cd661e332a98b60839c6caa',
             numberOfRecords: 6,
           },
           {
-            name: 'C',
+            species: '測試',
             speciesId: '5cd661e332a98b60839c6cab',
             numberOfRecords: 415,
           },
           {
-            name: 'D',
-            speciesId: '5cd661e332a98b60839c6cab',
+            species: '獼猴',
+            speciesId: '5cd661e332a98b60839c6cb1',
             numberOfRecords: 15,
           },
           {
-            name: 'E',
-            speciesId: '5cd661e332a98b60839c6cab',
+            species: '鼬獾',
+            speciesId: '5cd661e332a98b60839c6cb2',
             numberOfRecords: 83,
           },
         ],
@@ -411,6 +420,13 @@ export default {
         }),
       );
     },
+    speciesLegend: function() {
+      return Object.entries(this.species).map(([id, name], index) => ({
+        id,
+        name,
+        color: chartColors[index],
+      }));
+    },
     speciesMaxRecords: function() {
       return Object.values(this.speciesMarkers)
         .reduce((join, speciesMarkers) => [...join, ...speciesMarkers], [])
@@ -426,8 +442,8 @@ export default {
           speciesMarkers: this.speciesMarkers[id].map(
             ({ speciesId, numberOfRecords }, index) => ({
               speciesId,
-              color: chartColors[index],
-              radius: (numberOfRecords / this.speciesMaxRecords) * 2000,
+              color: this.getSpeciesMarkerColor(speciesId),
+              radius: (numberOfRecords / this.speciesMaxRecords) * 2000 + 200, // limit radius between 200 ~ 2200
               position: this.getRandomPosition(
                 position,
                 index,
@@ -442,8 +458,8 @@ export default {
         speciesMarkers: this.speciesMarkers[id].map(
           ({ speciesId, numberOfRecords }, index) => ({
             speciesId,
-            color: chartColors[index],
-            radius: (numberOfRecords / this.speciesMaxRecords) * 200,
+            color: this.getSpeciesMarkerColor(speciesId),
+            radius: (numberOfRecords / this.speciesMaxRecords) * 1000 + 100, // limit radius between 100 ~ 1100
             position: this.getRandomPosition(
               position,
               index,
@@ -599,6 +615,12 @@ export default {
         lng: lng + positonShift[idx].lng * scale,
       };
     },
+    getSpeciesMarkerColor(speciesId) {
+      if (!this.speciesLegend) return '';
+      const species = this.speciesLegend.find(({ id }) => id === speciesId);
+
+      return (species && species.color) || '';
+    },
   },
 };
 </script>
@@ -645,6 +667,21 @@ export default {
     display: flex;
     justify-content: space-between;
     color: #8b8b8b;
+  }
+}
+
+.species__legend > div {
+  position: relative;
+
+  & > span {
+    display: block;
+    position: absolute;
+    top: 4px;
+    left: -12px;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    border: 1px solid white;
   }
 }
 </style>

--- a/src/pages/Project/ProjectInfo/ProjectMap.vue
+++ b/src/pages/Project/ProjectInfo/ProjectMap.vue
@@ -99,10 +99,19 @@
         min="0"
         :max="totalDisplayMonth"
         :disabled="!showSpecies"
+        @mousedown="mousedownSlider"
+        @mousemove="mousemoveSlider"
+        @mouseup="mouseupSlider"
       />
+      <div
+        v-show="displayCurrentDate.show"
+        class="range__current"
+        :style="{ left: displayCurrentDate.x + 'px' }"
+      >
+        {{ currentDisplayDate }}
+      </div>
       <div class="range__display">
         <span>{{ startDisplayDate }}</span>
-        <span>{{ currentDisplayDate }}</span>
         <span>{{ endDisplayDate }}</span>
       </div>
     </div>
@@ -198,6 +207,10 @@ export default {
       displaySpeciesDate: 0,
       startDisplayDate: '2010-05', // TODO: get from API
       endDisplayDate: '2016-11', // TODO: get from API
+      displayCurrentDate: {
+        x: 0,
+        show: false,
+      },
     };
   },
   watch: {
@@ -367,6 +380,25 @@ export default {
     centerUpdated({ lat, lng }) {
       this.reloadForestBoundary({ lat, lng });
     },
+    mousedownSlider(e) {
+      this.displayCurrentDate = {
+        show: true,
+        x: e.layerX,
+      };
+    },
+    mousemoveSlider(e) {
+      const { target, layerX } = e;
+      if (
+        this.displayCurrentDate.show &&
+        layerX >= 0 &&
+        layerX <= target.clientWidth
+      ) {
+        this.displayCurrentDate.x = layerX;
+      }
+    },
+    mouseupSlider() {
+      this.displayCurrentDate.show = false;
+    },
   },
 };
 </script>
@@ -387,6 +419,8 @@ export default {
 }
 
 .range__container {
+  position: relative;
+
   & > input {
     width: 100%;
 
@@ -395,9 +429,22 @@ export default {
     }
   }
 
+  .range__current {
+    position: absolute;
+    top: -28px;
+    left: 0;
+    padding: 5px 10px;
+    border-radius: 3px;
+    width: 80px;
+    transform: translateX(-40px);
+    background-color: white;
+    color: #8b8b8b;
+  }
+
   .range__display {
     display: flex;
     justify-content: space-between;
+    color: #8b8b8b;
   }
 }
 </style>

--- a/src/pages/Project/ProjectInfo/ProjectMap.vue
+++ b/src/pages/Project/ProjectInfo/ProjectMap.vue
@@ -69,15 +69,42 @@
         />
       </l-layer-group>
     </l-map>
-    <div class="checkbox float-right mt-3 mb-0">
+    <div class="checkbox__container checkbox">
+      <div>
+        <input
+          type="checkbox"
+          name="show-species"
+          id="show-species"
+          value="1"
+          v-model="showSpecies"
+        />
+        <label for="show-species">顯示物種</label>
+      </div>
+      <div>
+        <input
+          type="checkbox"
+          name="show-woods"
+          id="show-woods"
+          value="1"
+          v-model="showForestBoundary"
+        />
+        <label for="show-woods">在地圖顯示林班地範圍</label>
+      </div>
+    </div>
+    <div class="range__container">
       <input
-        type="checkbox"
-        name="show-woods"
-        id="show-woods"
-        value="1"
-        v-model="showForestBoundary"
+        type="range"
+        name="speciesDate"
+        v-model="displaySpeciesDate"
+        min="0"
+        :max="totalDisplayMonth"
+        :disabled="!showSpecies"
       />
-      <label for="show-woods">在地圖顯示林班地範圍</label>
+      <div class="range__display">
+        <span>{{ startDisplayDate }}</span>
+        <span>{{ currentDisplayDate }}</span>
+        <span>{{ endDisplayDate }}</span>
+      </div>
     </div>
   </div>
 </template>
@@ -167,6 +194,10 @@ export default {
       attribution:
         '&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors',
       showForestBoundary: false,
+      showSpecies: false,
+      displaySpeciesDate: 0,
+      startDisplayDate: '2010-05', // TODO: get from API
+      endDisplayDate: '2016-11', // TODO: get from API
     };
   },
   watch: {
@@ -256,6 +287,33 @@ export default {
         lng: position.lng,
       };
     },
+    startDisplayYear: function() {
+      return parseInt(this.startDisplayDate.slice(0, 4), 10);
+    },
+    startDisplayMonth: function() {
+      return parseInt(this.startDisplayDate.slice(5), 10);
+    },
+    endDisplayYear: function() {
+      return parseInt(this.endDisplayDate.slice(0, 4), 10);
+    },
+    endDisplayMonth: function() {
+      return parseInt(this.endDisplayDate.slice(5), 10);
+    },
+    totalDisplayMonth: function() {
+      return (
+        (this.endDisplayYear - this.startDisplayYear) * 12 +
+        (this.endDisplayMonth - this.startDisplayMonth)
+      );
+    },
+    currentDisplayDate: function() {
+      // tranfer slider number to date
+      const num = parseInt(this.displaySpeciesDate, 10);
+      const totalMonth = this.startDisplayMonth + num;
+      const year = this.startDisplayYear + Math.floor((totalMonth - 1) / 12);
+      const month = totalMonth % 12 === 0 ? 12 : totalMonth % 12;
+
+      return `${year}-${('0' + month).slice(-2)}`;
+    },
   },
   methods: {
     ...forest.mapActions(['loadForestBoundary']),
@@ -312,3 +370,34 @@ export default {
   },
 };
 </script>
+<style lang="scss" scoped>
+.checkbox__container {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 16px;
+
+  & > div {
+    position: relative;
+
+    & > label {
+      padding-left: 25px;
+      font-size: 14px;
+    }
+  }
+}
+
+.range__container {
+  & > input {
+    width: 100%;
+
+    &:disabled {
+      cursor: not-allowed;
+    }
+  }
+
+  .range__display {
+    display: flex;
+    justify-content: space-between;
+  }
+}
+</style>

--- a/src/pages/Project/ProjectInfo/ProjectMap.vue
+++ b/src/pages/Project/ProjectInfo/ProjectMap.vue
@@ -74,7 +74,7 @@
         >
           <l-tooltip
             :content="camera.name"
-            :options="{ permanent: true, direction: 'top' }"
+            :options="{ permanent: true, direction: 'center' }"
           />
         </l-circle>
       </l-layer-group>
@@ -110,7 +110,7 @@
           :color="'#FFAF00'"
         />
       </l-layer-group>
-      <l-control position="topright" class="species__legend">
+      <l-control v-if="showSpecies" position="topright" class="species__legend">
         <div v-for="species in speciesLegend" :key="species.id">
           <span :style="{ backgroundColor: species.color }"></span>
           {{ species.name }}
@@ -144,6 +144,7 @@
         type="range"
         name="speciesDate"
         v-model="displaySpeciesDate"
+        step="1"
         min="0"
         :max="totalDisplayMonth - 1"
         :disabled="!showSpecies"
@@ -353,7 +354,7 @@ export default {
     speciesMarkers: function() {
       if (this.mapMode === 'byStudyArea') {
         return this.studyAreas.reduce((res, { position, id }) => {
-          const markers = this.speciesGroups[id].map(
+          const markers = (this.speciesGroups[id] || []).map(
             ({ speciesId, numberOfRecords }, index) => ({
               speciesId,
               color: this.getSpeciesMarkerColor(speciesId),
@@ -368,23 +369,21 @@ export default {
           return [...res, ...markers];
         }, []);
       }
-      // TODO: apply camera version
-      return [];
-      // return this.cameras.reduce((res, { position, id }) => {
-      //   const markers = this.speciesGroups[id].map(
-      //     ({ speciesId, numberOfRecords }, index) => ({
-      //       speciesId,
-      //       color: this.getSpeciesMarkerColor(speciesId),
-      //       radius: (numberOfRecords / this.speciesMaxRecords) * 1000 + 100, // limit radius between 100 ~ 1100
-      //       position: this.getRandomPosition(
-      //         position,
-      //         index,
-      //         this.cameraRadius,
-      //       ),
-      //     }),
-      //   );
-      //   return [...res, ...markers];
-      // }, []);
+      return this.cameras.reduce((res, { position, id }) => {
+        const markers = (this.speciesGroups[id] || []).map(
+          ({ speciesId, numberOfRecords }, index) => ({
+            speciesId,
+            color: this.getSpeciesMarkerColor(speciesId),
+            radius: (numberOfRecords / this.speciesMaxRecords) * 1000 + 100, // limit radius between 100 ~ 1100
+            position: this.getRandomPosition(
+              position,
+              index,
+              this.cameraRadius,
+            ),
+          }),
+        );
+        return [...res, ...markers];
+      }, []);
     },
     mapCenter: function() {
       // project level: calculate center base on all parent studyAreas
@@ -579,6 +578,7 @@ export default {
     transform: translateX(-40px);
     background-color: white;
     color: #8b8b8b;
+    box-shadow: 0px 0px 2px 0px black;
   }
 
   .range__display {

--- a/src/pages/Project/ProjectInfo/ProjectSpecies.vue
+++ b/src/pages/Project/ProjectInfo/ProjectSpecies.vue
@@ -72,18 +72,10 @@
 <script>
 import { createNamespacedHelpers } from 'vuex';
 import VueHighcharts from 'vue2-highcharts';
+import chartColors from '@/constant/chartColors';
 
 const projects = createNamespacedHelpers('projects');
 
-const chartColors = [
-  '#5DB897',
-  '#AACAEE',
-  '#7E99E5',
-  '#5569B5',
-  '#CC76BA',
-  '#FFC8EB',
-  '#BDE9A5',
-];
 export default {
   name: 'project-species',
   components: {

--- a/src/service/modules/studyAreas.js
+++ b/src/service/modules/studyAreas.js
@@ -122,7 +122,7 @@ const unlockProjectCameraLocations = async (projectId, cameraLocationId) => {
 };
 
 // TODO: apply when API ready
-const getSpeciesGroupByStudyArea = async projectId => {
+const getSpeciesGroupByStudyArea = async () => {
   return new Promise(resolve => {
     setTimeout(() => {
       resolve([
@@ -677,7 +677,7 @@ const getSpeciesGroupByStudyArea = async projectId => {
 };
 
 // TODO: apply when API ready
-const getSpeciesGroupByCameraLocation = async ({ projectId, studyAreaId }) => {
+const getSpeciesGroupByCameraLocation = async () => {
   return new Promise(resolve => {
     setTimeout(() => {
       resolve([

--- a/src/service/modules/studyAreas.js
+++ b/src/service/modules/studyAreas.js
@@ -121,6 +121,561 @@ const unlockProjectCameraLocations = async (projectId, cameraLocationId) => {
   return res;
 };
 
+// TODO: apply when API ready
+const getSpeciesGroupByStudyArea = async projectId => {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve([
+        {
+          studyAreaId: '5ceb8464caaeca01402d6354',
+          metrics: [
+            {
+              year: 2015,
+              month: 1,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 2,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 3,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 4,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 5,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 6,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 7,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 8,
+              metrics: [
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 54,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 81,
+                },
+              ],
+            },
+            {
+              year: 2015,
+              month: 9,
+              metrics: [
+                {
+                  species: '山羌',
+                  speciesId: '5cd661e332a98b60839c6caf',
+                  numberOfRecords: 1408,
+                },
+                {
+                  species: '空拍',
+                  speciesId: '5cd661e332a98b60839c6caa',
+                  numberOfRecords: 45,
+                },
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 3055,
+                },
+                {
+                  species: '獼猴',
+                  speciesId: '5cd661e332a98b60839c6cb1',
+                  numberOfRecords: 201,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 335,
+                },
+              ],
+            },
+            {
+              year: 2015,
+              month: 10,
+              metrics: [
+                {
+                  species: '山羌',
+                  speciesId: '5cd661e332a98b60839c6caf',
+                  numberOfRecords: 2497,
+                },
+                {
+                  species: '獼猴',
+                  speciesId: '5cd661e332a98b60839c6cb1',
+                  numberOfRecords: 423,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 434,
+                },
+                {
+                  species: '空拍',
+                  speciesId: '5cd661e332a98b60839c6caa',
+                  numberOfRecords: 279,
+                },
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 1944,
+                },
+              ],
+            },
+            {
+              year: 2015,
+              month: 11,
+              metrics: [
+                {
+                  species: '空拍',
+                  speciesId: '5cd661e332a98b60839c6caa',
+                  numberOfRecords: 3481,
+                },
+                {
+                  species: '獼猴',
+                  speciesId: '5cd661e332a98b60839c6cb1',
+                  numberOfRecords: 424,
+                },
+                {
+                  species: '山羌',
+                  speciesId: '5cd661e332a98b60839c6caf',
+                  numberOfRecords: 2480,
+                },
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 1944,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 239,
+                },
+              ],
+            },
+            {
+              year: 2015,
+              month: 12,
+              metrics: [
+                {
+                  species: '山羌',
+                  speciesId: '5cd661e332a98b60839c6caf',
+                  numberOfRecords: 2860,
+                },
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 1910,
+                },
+                {
+                  species: '獼猴',
+                  speciesId: '5cd661e332a98b60839c6cb1',
+                  numberOfRecords: 471,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 178,
+                },
+                {
+                  species: '空拍',
+                  speciesId: '5cd661e332a98b60839c6caa',
+                  numberOfRecords: 249,
+                },
+              ],
+            },
+          ],
+        },
+        {
+          studyAreaId: '5ceb83f7caaecaca502d62d9',
+          metrics: [
+            {
+              year: 2015,
+              month: 1,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 2,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 3,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 4,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 5,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 6,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 7,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 8,
+              metrics: [
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 54,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 81,
+                },
+              ],
+            },
+            {
+              year: 2015,
+              month: 9,
+              metrics: [
+                {
+                  species: '山羌',
+                  speciesId: '5cd661e332a98b60839c6caf',
+                  numberOfRecords: 1408,
+                },
+                {
+                  species: '空拍',
+                  speciesId: '5cd661e332a98b60839c6caa',
+                  numberOfRecords: 45,
+                },
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 3055,
+                },
+                {
+                  species: '獼猴',
+                  speciesId: '5cd661e332a98b60839c6cb1',
+                  numberOfRecords: 201,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 335,
+                },
+              ],
+            },
+            {
+              year: 2015,
+              month: 10,
+              metrics: [
+                {
+                  species: '山羌',
+                  speciesId: '5cd661e332a98b60839c6caf',
+                  numberOfRecords: 2497,
+                },
+                {
+                  species: '獼猴',
+                  speciesId: '5cd661e332a98b60839c6cb1',
+                  numberOfRecords: 423,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 434,
+                },
+                {
+                  species: '空拍',
+                  speciesId: '5cd661e332a98b60839c6caa',
+                  numberOfRecords: 279,
+                },
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 1944,
+                },
+              ],
+            },
+            {
+              year: 2015,
+              month: 11,
+              metrics: [
+                {
+                  species: '空拍',
+                  speciesId: '5cd661e332a98b60839c6caa',
+                  numberOfRecords: 3481,
+                },
+                {
+                  species: '獼猴',
+                  speciesId: '5cd661e332a98b60839c6cb1',
+                  numberOfRecords: 424,
+                },
+                {
+                  species: '山羌',
+                  speciesId: '5cd661e332a98b60839c6caf',
+                  numberOfRecords: 2480,
+                },
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 1944,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 239,
+                },
+              ],
+            },
+            {
+              year: 2015,
+              month: 12,
+              metrics: [
+                {
+                  species: '山羌',
+                  speciesId: '5cd661e332a98b60839c6caf',
+                  numberOfRecords: 2860,
+                },
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 1910,
+                },
+                {
+                  species: '獼猴',
+                  speciesId: '5cd661e332a98b60839c6cb1',
+                  numberOfRecords: 471,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 178,
+                },
+                {
+                  species: '空拍',
+                  speciesId: '5cd661e332a98b60839c6caa',
+                  numberOfRecords: 249,
+                },
+              ],
+            },
+          ],
+        },
+        {
+          studyAreaId: '5ceb8488caaecaf5472d63a8',
+          metrics: [
+            {
+              year: 2015,
+              month: 1,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 2,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 3,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 4,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 5,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 6,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 7,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 8,
+              metrics: [
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 54,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 81,
+                },
+              ],
+            },
+            {
+              year: 2015,
+              month: 9,
+              metrics: [
+                {
+                  species: '山羌',
+                  speciesId: '5cd661e332a98b60839c6caf',
+                  numberOfRecords: 1408,
+                },
+                {
+                  species: '空拍',
+                  speciesId: '5cd661e332a98b60839c6caa',
+                  numberOfRecords: 45,
+                },
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 3055,
+                },
+                {
+                  species: '獼猴',
+                  speciesId: '5cd661e332a98b60839c6cb1',
+                  numberOfRecords: 201,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 335,
+                },
+              ],
+            },
+            {
+              year: 2015,
+              month: 10,
+              metrics: [
+                {
+                  species: '山羌',
+                  speciesId: '5cd661e332a98b60839c6caf',
+                  numberOfRecords: 2497,
+                },
+                {
+                  species: '獼猴',
+                  speciesId: '5cd661e332a98b60839c6cb1',
+                  numberOfRecords: 423,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 434,
+                },
+                {
+                  species: '空拍',
+                  speciesId: '5cd661e332a98b60839c6caa',
+                  numberOfRecords: 279,
+                },
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 1944,
+                },
+              ],
+            },
+            {
+              year: 2015,
+              month: 11,
+              metrics: [
+                {
+                  species: '空拍',
+                  speciesId: '5cd661e332a98b60839c6caa',
+                  numberOfRecords: 3481,
+                },
+                {
+                  species: '獼猴',
+                  speciesId: '5cd661e332a98b60839c6cb1',
+                  numberOfRecords: 424,
+                },
+                {
+                  species: '山羌',
+                  speciesId: '5cd661e332a98b60839c6caf',
+                  numberOfRecords: 2480,
+                },
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 1944,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 239,
+                },
+              ],
+            },
+            {
+              year: 2015,
+              month: 12,
+              metrics: [
+                {
+                  species: '山羌',
+                  speciesId: '5cd661e332a98b60839c6caf',
+                  numberOfRecords: 2860,
+                },
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 1910,
+                },
+                {
+                  species: '獼猴',
+                  speciesId: '5cd661e332a98b60839c6cb1',
+                  numberOfRecords: 471,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 178,
+                },
+                {
+                  species: '空拍',
+                  speciesId: '5cd661e332a98b60839c6caa',
+                  numberOfRecords: 249,
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+    }, 500);
+  });
+  // const res = await fetchWrap({
+  //   url: `/api/v1/projects/${projectId}/camera-locations`,
+  //   method: 'GET',
+  // });
+  // return res;
+};
+
 export {
   getProjectStudyAreas,
   getAllProjectCameraLocations,
@@ -132,4 +687,5 @@ export {
   getProjectCameraLocationsByName,
   lockProjectCameraLocations,
   unlockProjectCameraLocations,
+  getSpeciesGroupByStudyArea,
 };

--- a/src/service/modules/studyAreas.js
+++ b/src/service/modules/studyAreas.js
@@ -676,6 +676,381 @@ const getSpeciesGroupByStudyArea = async projectId => {
   // return res;
 };
 
+// TODO: apply when API ready
+const getSpeciesGroupByCameraLocation = async ({ projectId, studyAreaId }) => {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve([
+        {
+          cameraLocationId: '5ceb8464caaecacfc62d6356',
+          metrics: [
+            {
+              year: 2015,
+              month: 1,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 2,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 3,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 4,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 5,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 6,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 7,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 8,
+              metrics: [
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 54,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 81,
+                },
+              ],
+            },
+            {
+              year: 2015,
+              month: 9,
+              metrics: [
+                {
+                  species: '山羌',
+                  speciesId: '5cd661e332a98b60839c6caf',
+                  numberOfRecords: 1408,
+                },
+                {
+                  species: '空拍',
+                  speciesId: '5cd661e332a98b60839c6caa',
+                  numberOfRecords: 45,
+                },
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 3055,
+                },
+                {
+                  species: '獼猴',
+                  speciesId: '5cd661e332a98b60839c6cb1',
+                  numberOfRecords: 201,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 335,
+                },
+              ],
+            },
+            {
+              year: 2015,
+              month: 10,
+              metrics: [
+                {
+                  species: '山羌',
+                  speciesId: '5cd661e332a98b60839c6caf',
+                  numberOfRecords: 2497,
+                },
+                {
+                  species: '獼猴',
+                  speciesId: '5cd661e332a98b60839c6cb1',
+                  numberOfRecords: 423,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 434,
+                },
+                {
+                  species: '空拍',
+                  speciesId: '5cd661e332a98b60839c6caa',
+                  numberOfRecords: 279,
+                },
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 1944,
+                },
+              ],
+            },
+            {
+              year: 2015,
+              month: 11,
+              metrics: [
+                {
+                  species: '空拍',
+                  speciesId: '5cd661e332a98b60839c6caa',
+                  numberOfRecords: 3481,
+                },
+                {
+                  species: '獼猴',
+                  speciesId: '5cd661e332a98b60839c6cb1',
+                  numberOfRecords: 424,
+                },
+                {
+                  species: '山羌',
+                  speciesId: '5cd661e332a98b60839c6caf',
+                  numberOfRecords: 2480,
+                },
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 1944,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 239,
+                },
+              ],
+            },
+            {
+              year: 2015,
+              month: 12,
+              metrics: [
+                {
+                  species: '山羌',
+                  speciesId: '5cd661e332a98b60839c6caf',
+                  numberOfRecords: 2860,
+                },
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 1910,
+                },
+                {
+                  species: '獼猴',
+                  speciesId: '5cd661e332a98b60839c6cb1',
+                  numberOfRecords: 471,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 178,
+                },
+                {
+                  species: '空拍',
+                  speciesId: '5cd661e332a98b60839c6caa',
+                  numberOfRecords: 249,
+                },
+              ],
+            },
+          ],
+        },
+        {
+          cameraLocationId: '5ceb8465caaeca3e052d6358',
+          metrics: [
+            {
+              year: 2015,
+              month: 1,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 2,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 3,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 4,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 5,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 6,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 7,
+              metrics: [],
+            },
+            {
+              year: 2015,
+              month: 8,
+              metrics: [
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 54,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 81,
+                },
+              ],
+            },
+            {
+              year: 2015,
+              month: 9,
+              metrics: [
+                {
+                  species: '山羌',
+                  speciesId: '5cd661e332a98b60839c6caf',
+                  numberOfRecords: 1408,
+                },
+                {
+                  species: '空拍',
+                  speciesId: '5cd661e332a98b60839c6caa',
+                  numberOfRecords: 45,
+                },
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 3055,
+                },
+                {
+                  species: '獼猴',
+                  speciesId: '5cd661e332a98b60839c6cb1',
+                  numberOfRecords: 201,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 335,
+                },
+              ],
+            },
+            {
+              year: 2015,
+              month: 10,
+              metrics: [
+                {
+                  species: '山羌',
+                  speciesId: '5cd661e332a98b60839c6caf',
+                  numberOfRecords: 2497,
+                },
+                {
+                  species: '獼猴',
+                  speciesId: '5cd661e332a98b60839c6cb1',
+                  numberOfRecords: 423,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 434,
+                },
+                {
+                  species: '空拍',
+                  speciesId: '5cd661e332a98b60839c6caa',
+                  numberOfRecords: 279,
+                },
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 1944,
+                },
+              ],
+            },
+            {
+              year: 2015,
+              month: 11,
+              metrics: [
+                {
+                  species: '空拍',
+                  speciesId: '5cd661e332a98b60839c6caa',
+                  numberOfRecords: 3481,
+                },
+                {
+                  species: '獼猴',
+                  speciesId: '5cd661e332a98b60839c6cb1',
+                  numberOfRecords: 424,
+                },
+                {
+                  species: '山羌',
+                  speciesId: '5cd661e332a98b60839c6caf',
+                  numberOfRecords: 2480,
+                },
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 1944,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 239,
+                },
+              ],
+            },
+            {
+              year: 2015,
+              month: 12,
+              metrics: [
+                {
+                  species: '山羌',
+                  speciesId: '5cd661e332a98b60839c6caf',
+                  numberOfRecords: 2860,
+                },
+                {
+                  species: '測試',
+                  speciesId: '5cd661e332a98b60839c6cab',
+                  numberOfRecords: 1910,
+                },
+                {
+                  species: '獼猴',
+                  speciesId: '5cd661e332a98b60839c6cb1',
+                  numberOfRecords: 471,
+                },
+                {
+                  species: '鼬獾',
+                  speciesId: '5cd661e332a98b60839c6cb2',
+                  numberOfRecords: 178,
+                },
+                {
+                  species: '空拍',
+                  speciesId: '5cd661e332a98b60839c6caa',
+                  numberOfRecords: 249,
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+    }, 500);
+  });
+  // const res = await fetchWrap({
+  //   url: `/api/v1/projects/${projectId}/camera-locations`,
+  //   method: 'GET',
+  // });
+  // return res;
+};
+
 export {
   getProjectStudyAreas,
   getAllProjectCameraLocations,
@@ -688,4 +1063,5 @@ export {
   lockProjectCameraLocations,
   unlockProjectCameraLocations,
   getSpeciesGroupByStudyArea,
+  getSpeciesGroupByCameraLocation,
 };

--- a/src/store/modules/projects/projects.js
+++ b/src/store/modules/projects/projects.js
@@ -84,12 +84,8 @@ const getters = {
     if (permission && permission.role === 'researcher') return true;
     return false;
   },
-  identifiedSpecies: state => {
-    const records = idx(state, _ => _.identifiedSpecies.records) || [];
-    records.sort(({ count: countA }, { count: countB }) => countB - countA);
-
-    return records;
-  },
+  identifiedSpecies: state =>
+    idx(state, _ => _.identifiedSpecies.records) || [],
   identifiedSpeciesLastUpdate: state => {
     const timeUpdated = idx(state, _ => _.identifiedSpecies.timeUpdated);
 
@@ -163,7 +159,15 @@ const mutations = {
     state.projectSpecies = data;
   },
   setIdentifiedSpecies(state, data) {
-    state.identifiedSpecies = data;
+    let records = [];
+    if (data.records && data.records.length > 0) {
+      records = [...data.records];
+      records.sort(({ count: countA }, { count: countB }) => countB - countA);
+    }
+    state.identifiedSpecies = {
+      ...data,
+      records,
+    };
   },
   setRetrievalStatus(state, status) {
     Vue.set(state.retrievalData, 'loadingStatus', status);

--- a/src/store/modules/projects/studyAreas.js
+++ b/src/store/modules/projects/studyAreas.js
@@ -7,6 +7,7 @@ import {
   getAllProjectCameraLocations,
   getProjectCameraLocations,
   getProjectStudyAreas,
+  getSpeciesGroupByStudyArea,
   lockProjectCameraLocations,
   postProjectCameraLocations,
   postProjectStudyAreas,
@@ -14,12 +15,17 @@ import {
   unlockProjectCameraLocations,
 } from '@/service';
 import { getLanguage } from '@/utils/i18n';
+import { setTwoDigitFormat } from '@/utils/dateHelper';
 
 // 計畫內的樣區資訊，全放在 project 會過大
 
 const state = {
   studyAreas: [], // 計畫樣區列表
   cameraLocations: [], // 指定樣區內的相機位置列表，只保存最後一次的查詢結果
+  speciesGroup: {
+    byStudyArea: [], // 各樣區的前五大物種與回收影像數量
+    byCameraLocation: [], // 各相機的前五大物種與回收影像數量
+  },
 };
 
 const getters = {
@@ -54,6 +60,49 @@ const getters = {
     });
     return title;
   },
+  speciesGroupStartDate: state => {
+    const firstDate = idx(state, _ => _.speciesGroup.byStudyArea[0].metrics[0]);
+    if (!firstDate) return '';
+    return `${firstDate.year}-${setTwoDigitFormat(firstDate.month)}`;
+  },
+  speciesGroupEndDate: state => {
+    const metrics = idx(state, _ => _.speciesGroup.byStudyArea[0].metrics);
+    if (!metrics || metrics.length === 0) return '';
+
+    const lastDate = metrics[metrics.length - 1];
+    return `${lastDate.year}-${setTwoDigitFormat(lastDate.month)}`;
+  },
+  topFiveSpecies: state => {
+    const speciesGroup = idx(state, _ => _.speciesGroup.byStudyArea) || [];
+    const allSpeciesData = speciesGroup.reduce((res, group) => {
+      return group.metrics.reduce(
+        (merge, { metrics }) => [...merge, ...metrics],
+        res,
+      );
+    }, []);
+
+    let topFive = {};
+    allSpeciesData.some(({ speciesId, species }) => {
+      topFive[speciesId] = species;
+      return topFive.length >= 5;
+    });
+    return topFive;
+  },
+  getSpeciesGroups: state => ({ type, date }) => {
+    const group = idx(state, _ => _.speciesGroup[type]) || [];
+
+    return group.reduce((res, { studyAreaId, metrics }) => {
+      const selectedDateSpecies =
+        metrics.find(
+          ({ year, month }) => `${year}-${setTwoDigitFormat(month)}` === date,
+        ) || [];
+
+      return {
+        ...res,
+        [studyAreaId]: selectedDateSpecies.metrics,
+      };
+    }, {});
+  },
 };
 
 const mutations = {
@@ -65,6 +114,9 @@ const mutations = {
   },
   resetCameraLocations(state) {
     state.cameraLocations = [];
+  },
+  setSpeciesGroup(state, { type, data }) {
+    state.speciesGroup[type] = data;
   },
 };
 
@@ -133,6 +185,10 @@ const actions = {
       ),
     );
     dispatch('getProjectCameraLocations', { projectId, studyAreaId });
+  },
+  async loadSpeciesGroupByStudyArea({ commit }, { projectId }) {
+    const data = await getSpeciesGroupByStudyArea(projectId);
+    commit('setSpeciesGroup', { type: 'byStudyArea', data });
   },
 };
 

--- a/src/store/modules/projects/studyAreas.js
+++ b/src/store/modules/projects/studyAreas.js
@@ -7,6 +7,7 @@ import {
   getAllProjectCameraLocations,
   getProjectCameraLocations,
   getProjectStudyAreas,
+  getSpeciesGroupByCameraLocation,
   getSpeciesGroupByStudyArea,
   lockProjectCameraLocations,
   postProjectCameraLocations,
@@ -91,7 +92,7 @@ const getters = {
   getSpeciesGroups: state => ({ type, date }) => {
     const group = idx(state, _ => _.speciesGroup[type]) || [];
 
-    return group.reduce((res, { studyAreaId, metrics }) => {
+    return group.reduce((res, { studyAreaId, cameraLocationId, metrics }) => {
       const selectedDateSpecies =
         metrics.find(
           ({ year, month }) => `${year}-${setTwoDigitFormat(month)}` === date,
@@ -99,7 +100,7 @@ const getters = {
 
       return {
         ...res,
-        [studyAreaId]: selectedDateSpecies.metrics,
+        [studyAreaId || cameraLocationId]: selectedDateSpecies.metrics,
       };
     }, {});
   },
@@ -189,6 +190,16 @@ const actions = {
   async loadSpeciesGroupByStudyArea({ commit }, { projectId }) {
     const data = await getSpeciesGroupByStudyArea(projectId);
     commit('setSpeciesGroup', { type: 'byStudyArea', data });
+  },
+  async loadSpeciesGroupByCameraLocation(
+    { commit },
+    { projectId, studyAreaId },
+  ) {
+    const data = await getSpeciesGroupByCameraLocation({
+      projectId,
+      studyAreaId,
+    });
+    commit('setSpeciesGroup', { type: 'byCameraLocation', data });
   },
 };
 

--- a/src/utils/dateHelper.js
+++ b/src/utils/dateHelper.js
@@ -20,3 +20,5 @@ export const dateFormatYYYYMMDDHHmmss = dateTimeString =>
 export const dateFormatYYYY = dateTimeString => {
   return moment(dateTimeString).format('YYYY');
 };
+
+export const setTwoDigitFormat = num => ('0' + num).slice(-2);


### PR DESCRIPTION
relate to: #182
(API 還沒 ready, 先處理畫面與 Vuex)
PS. 這邊是暫時 hardcode 此 project 的假資料 
http://localhost:8888/project/5ceb83f6caaeca497b2d62c5/info/media/all/retrieved

* 增加 `顯示物種` checkbox
* 增加 slider for 物種資料對應月份
* 物種 marker
* legend for 物種
* 顯示物種時, 調整 studyArea / cameraLocation marker 的 fillcolor 為半透明



---
### by study area
![Jun-02-2019 10-24-43](https://user-images.githubusercontent.com/13633490/58755982-85664d80-8521-11e9-9a33-630bb6ba36c5.gif)

### by camera location
![Jun-02-2019 10-26-21](https://user-images.githubusercontent.com/13633490/58755986-99aa4a80-8521-11e9-87f6-03206b0bfcf5.gif)


