### PR TITLE
feat: 利用 setInterval 持續監聽 sheet 高度

### DIFF
--- a/src/pages/Project/ProjectStudyAreas/AnnotationsSheet.vue
+++ b/src/pages/Project/ProjectStudyAreas/AnnotationsSheet.vue
@@ -168,6 +168,7 @@ export default {
     return {
       showErrorMessage: true,
       idleTimeevent: -1,
+      sheetHeightTimeevent: -1,
       showIdleModal: false,
       isEnableContinuous: false,
       continuousMinute: 3,
@@ -298,8 +299,11 @@ export default {
       this.setSheetHeight();
       this.setSheetHeader();
       this.setSheetColumn();
-      window.onresize = () => this.setSheetHeight();
     }, 500);
+
+    this.sheetHeightTimeevent = setInterval(() => {
+      this.setSheetHeight(false);
+    }, 100);
 
     // 編輯中離開頁面警告
     window.onbeforeunload = () => {
@@ -309,6 +313,7 @@ export default {
   beforeDestroy() {
     window.onbeforeunload = null;
     clearTimeout(this.idleTimeevent);
+    clearInterval(this.sheetHeightTimeevent);
   },
   watch: {
     continuousRange: function(newVal, oldVal) {
@@ -466,7 +471,7 @@ export default {
         this.showIdleModal = true;
       }, 1000 * 60 * 30); // 30 分鐘
     },
-    setSheetHeight() {
+    setSheetHeight(isForce = true) {
       const sheetHeight =
         window.innerHeight -
         document.querySelector('header').clientHeight -
@@ -474,11 +479,12 @@ export default {
         document.querySelector('.sheet-footer').clientHeight -
         document.querySelector('.sheet-header').clientHeight;
 
-      this.HandsontableSetting.height = sheetHeight;
-
-      this.$nextTick(() => {
-        this.$refs.sheet.hotInstance.render();
-      });
+      if (isForce === true || this.HandsontableSetting.height !== sheetHeight) {
+        this.HandsontableSetting.height = sheetHeight;
+        this.$nextTick(() => {
+          this.$refs.sheet.hotInstance.render();
+        });
+      }
     },
     afterOnCellMouseDown(event) {
       this.currentMouseButton = event.button;


### PR DESCRIPTION
因為 handsontable 沒辦法直接自動設定高度為匹配畫面高度，所以總會造成高度不正確
多個資料都有可能造成高度改變，所以直接使用 setInterval 持續計算高度，如果有變就 rerender sheet

以下幾個是測試方式，確認高度以及 sheet 沒有灰色色塊
- 切換相機位置數量不同的樣區, ex: 利嘉野生動物重要棲息環境哺乳類與鳥類資源調查計畫(二)
- 開關側邊選單以及拖拉側邊選單寬度
- 在同一個畫面直接 F5 刷新畫面